### PR TITLE
Graph to board

### DIFF
--- a/src/Graph.spec.ts
+++ b/src/Graph.spec.ts
@@ -23,17 +23,17 @@ describe("boardToGraph", () => {
 });
 
 describe("graphToBoard", () => {
-  it("should return a well formed Board when a graph is passed as argument with the graphToBoard function", () => {});
+  it("should return a well formed Board when a graph is passed as argument with the graphToBoard function", () => {
+    const customBoard: Board = [
+      [1, 2, 0],
+      [2, 2, 2],
+      [3, 1, 0],
+    ];
 
-  const customBoard: Board = [
-    [1, 2, 0],
-    [2, 2, 2],
-    [3, 1, 0],
-  ];
+    const graph: Graph = boardToGraph(customBoard);
 
-  const graph: Graph = boardToGraph(customBoard);
+    const boardFromGraph: Board = graphToBoard(graph);
 
-  const boardFromGraph: Board = graphToBoard(graph);
-
-  expect(boardFromGraph).toEqual(customBoard);
+    expect(boardFromGraph).toEqual(customBoard);
+  });
 });

--- a/src/Graph.spec.ts
+++ b/src/Graph.spec.ts
@@ -1,7 +1,7 @@
 import expect from "expect";
 import { Graph, Board } from "./Types";
 import { getInitialBoard } from "./Board";
-import { boardToGraph } from "./Graph";
+import { boardToGraph, graphToBoard } from "./Graph";
 
 const INITAL_BOARD: Board = [
   [1, 1, 1],
@@ -10,14 +10,30 @@ const INITAL_BOARD: Board = [
 ];
 
 describe("boardToGraph", () => {
-  it("should return a well formed Graph when a Board is passed as argument with the boardToGraph method", () => {
-    const GRAPH: Graph = boardToGraph(INITAL_BOARD);
+  it("should return a well formed Graph when a Board is passed as argument with the boardToGraph function", () => {
+    const graph: Graph = boardToGraph(INITAL_BOARD);
 
-    expect(GRAPH.nodes).toBeTruthy();
-    expect(GRAPH.nodes["0,0"].value).toBe(1);
-    expect(GRAPH.nodes["1,1"].isExit).toBe(false);
-    expect(GRAPH.nodes["0,1"].isExit).toBe(true);
-    expect(GRAPH.edges[0].from).toBe("0,0");
-    expect(GRAPH);
+    expect(graph.nodes).toBeTruthy();
+    expect(graph.nodes["0,0"].value).toBe(1);
+    expect(graph.nodes["1,1"].isExit).toBe(false);
+    expect(graph.nodes["0,1"].isExit).toBe(true);
+    expect(graph.edges[0].from).toBe("0,0");
+    expect(graph);
   });
+});
+
+describe("graphToBoard", () => {
+  it("should return a well formed Board when a graph is passed as argument with the graphToBoard function", () => {});
+
+  const customBoard: Board = [
+    [1, 2, 0],
+    [2, 2, 2],
+    [3, 1, 0],
+  ];
+
+  const graph: Graph = boardToGraph(customBoard);
+
+  const boardFromGraph: Board = graphToBoard(graph);
+
+  expect(boardFromGraph).toEqual(customBoard);
 });

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -73,3 +73,9 @@ function isAnExit(board: Board, x: number, y: number) {
     y === lastRowIndex
   );
 }
+
+export const graphToBoard = (graph: Graph): Board => {
+  let board: Board;
+
+  return board;
+};

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -75,12 +75,10 @@ function isAnExit(board: Board, x: number, y: number) {
 }
 
 export const graphToBoard = (graph: Graph): Board => {
-  let board: Board = [[]];
-  let maxDimension = 0;
+  const board: Board = [[]];
   for (const index in graph.nodes) {
     const node: Node = graph.nodes[index];
-    if (node.y > maxDimension) {
-      maxDimension++;
+    if (!board[node.y]) {
       board.push([]);
     }
     board[node.y][node.x] = node.value;

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -75,7 +75,15 @@ function isAnExit(board: Board, x: number, y: number) {
 }
 
 export const graphToBoard = (graph: Graph): Board => {
-  let board: Board;
-
+  let board: Board = [[]];
+  let maxDimension = 0;
+  for (const index in graph.nodes) {
+    const node: Node = graph.nodes[index];
+    if (node.y > maxDimension) {
+      maxDimension++;
+      board.push([]);
+    }
+    board[node.y][node.x] = node.value;
+  }
   return board;
 };


### PR DESCRIPTION
Simple function to transform a `Graph` into a `Board`.
Linked to `Card #2`