### PR TITLE
Add error for understand why a move is not allowed

### DIFF
--- a/src/Board.spec.ts
+++ b/src/Board.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "./Board";
 import { boardToGraph } from "./Graph";
 import { close } from "./UserInput";
+import { CantMoveError } from "./error";
 
 describe("Board test", () => {
   let firstBoard;
@@ -43,8 +44,10 @@ describe("Board test", () => {
   describe("canMoveMarbleInDirection", () => {
     it("should return true or false when a position, a direction and a Graph is passed as parameter with the canMoveMarbleInDirection function", () => {
       const graph = boardToGraph(firstBoard);
+      const error = new CantMoveError('This move is not allowed');
+
       expect(canMoveMarbleInDirection(graph, "0,0", "E")).toBe(true);
-      expect(canMoveMarbleInDirection(graph, "1,0", "E")).toBe(false);
+      expect(() => {canMoveMarbleInDirection(graph, "1,0", "E")}).toThrowError(error);
     });
   });
 });

--- a/src/Board.ts
+++ b/src/Board.ts
@@ -9,6 +9,7 @@ import {
   graphToBoard
 } from "./Graph";
 import { renderToConsole, renderBoard } from "./RenderBoard";
+import { CantMoveError } from "./error";
 
 const DIRECTIONS: DirectionInBoard = {
   E: {
@@ -90,17 +91,26 @@ export function canMoveMarbleInDirection(
   marblePosition: string,
   direction: string
 ): Boolean {
-  return (
-    positionExistsInBoard(boardGraph, marblePosition) &&
-    hasFreeSpotBeforeToMove(boardGraph, marblePosition, direction)
-  );
+  
+    const existInBoard = positionExistsInBoard(boardGraph, marblePosition);
+    if (!existInBoard) {
+        throw new CantMoveError('This position not exist in board')
+    }
+
+    const freeSpotBeforeToMove = hasFreeSpotBeforeToMove(boardGraph, marblePosition, direction);
+    if (!freeSpotBeforeToMove) {
+      throw new CantMoveError('This move is not allowed')
+    }
+
+    return existInBoard && freeSpotBeforeToMove;
+  ;
 }
 
 function positionExistsInBoard(
   boardGraph: Graph,
   marblePosition: string
 ): Boolean {
-  return !!boardGraph.nodes[marblePosition];
+  return !!boardGraph.nodes[marblePosition]
 }
 
 function hasFreeSpotBeforeToMove(
@@ -135,10 +145,6 @@ export function moveMarble(
     stringCoordinate,
     userMove.marbleDirection
   );
-
-  if (!canMove) {
-    console.log("This movement is not possible");
-  }
 
   const movedGraph = moveMarbleInDirection(
     boardGraph,

--- a/src/Graph.spec.ts
+++ b/src/Graph.spec.ts
@@ -7,6 +7,7 @@ import {
   moveMarbleInDirection,
   graphToBoard
 } from "./Graph";
+import { UserPositionError } from "./error";
 
 const INITIAL_BOARD: Board = [
   [1, 1, 1],
@@ -51,12 +52,11 @@ describe("graphToBoard", () => {
     expect(coordinate).toStrictEqual(coordinateResult);
   });
 
-  it("should return a coordinate outside the board box if position not match pattern", () => {
+  it("should throw an error if position not match pattern", () => {
     const position = "13D";
+    const error = new UserPositionError('This position is not well formatted');
 
-    const coordinate = positionToCoordinate(position);
-
-    expect(coordinate).toStrictEqual({ x: -1, y: -1 });
+    expect(() => {positionToCoordinate(position)}).toThrowError(error)
   });
 
   it("should not move marbles because start on value 0", () => {

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -1,5 +1,6 @@
 import { Graph, Board, Edge, Node } from "./Types";
 import { ALPHABET } from "./RenderBoard";
+import { UserPositionError } from "./error";
 
 export function boardToGraph(board: Board): Graph {
   if (board.length < 1) return newBlankGraph();
@@ -80,7 +81,7 @@ export function positionToCoordinate(position: string): {
   y: number;
 } {
   if (position.length > 3) {
-    return { x: -1, y: -1 };
+    throw new UserPositionError('This position is longer than 3 characters')
   }
 
   const positionSplit = position.split("");
@@ -89,7 +90,7 @@ export function positionToCoordinate(position: string): {
   const y = parseInt(positionSplit[1] + positionSplit[2]);
 
   if (x === -1 || y < 0) {
-    return { x: -1, y: -1 };
+    throw new UserPositionError('This position is not well formatted')
   }
 
   return { x, y };

--- a/src/UserInput.ts
+++ b/src/UserInput.ts
@@ -2,8 +2,6 @@ import { Direction } from "./Types";
 
 const readline = require("readline");
 
-// The readline module provides an interface for reading data from a Readable stream (such as process.stdin) one line at a time. 
-// This is used to manage the communication between our player and the application
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
@@ -24,7 +22,6 @@ export function askUserBoardPath(): Promise<string> {
 export async function askUserMove(): Promise<{marblePosition: string, marbleDirection: Direction}> {
   const marblePosition = await marble();
   const marbleDirection = await direction();
-  close();
   return {marblePosition, marbleDirection}
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,15 @@
+export class CantMoveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CantMoveError";
+    console.log(`\u001b[31m${message} \u001b[0m`);
+  }
+}
+
+export class UserPositionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserPositionError";
+    console.log(`\u001b[31m${message} \u001b[0m`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,17 @@ async function main() {
   }
   const graphicalBoard = renderBoard(board);
   renderToConsole(graphicalBoard);
-  const userMove = await askUserMove();
-  moveMarble(board, userMove)
+
+  let userMove = await askUserMove();
+
+  try {
+    moveMarble(board, userMove);
+  }catch {
+    userMove = await askUserMove();
+    moveMarble(board, userMove);
+  }
+  
+  close();
 }
 
 main();


### PR DESCRIPTION
- Add errors than extend `Error`
- Throw specific error on `positionToCoordinate` and `canMoveMarbleInDirection`
- console.log errors for players
- test `toThrow`
![image](https://user-images.githubusercontent.com/18294269/131816872-f60102ed-b22c-438a-bfca-004fe08cd94f.png)
